### PR TITLE
i18n/backup safety nums

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -1480,7 +1480,7 @@
     <string name="registration_activity__skip">Skip</string>
     <string name="registration_activity__register">Register</string>
     <string name="preferences_chats__chat_backups">Chat backups</string>
-    <string name="preferences_chats__backup_chats_to_external_storage">Backup chats to external storage</string>
+    <string name="preferences_chats__backup_chats_media_and_safety_numbers_to_external_storage">Backup chats, media, and safety-numbers to external storage</string>
     <string name="preferences_chats__create_backup">Create backup</string>
     <string name="RegistrationActivity_enter_backup_passphrase">Enter backup passphrase</string>
     <string name="RegistrationActivity_restore">Restore</string>
@@ -1489,7 +1489,7 @@
     <string name="RegistrationActivity_checking">Checking...</string>
     <string name="RegistrationActivity_d_messages_so_far">%d messages so far...</string>
     <string name="RegistrationActivity_restore_from_backup">Restore from backup?</string>
-    <string name="RegistrationActivity_restore_your_messages_and_media_from_a_local_backup">Restore your messages and media from a local backup. If you don\'t restore now, you won\'t be able to restore later.</string>
+    <string name="RegistrationActivity_restore_your_chats_media_and_safety_numbers_from_a_local_backup">Restore your chats, media, and safety-numbers from a local backup. If you don\'t restore now, you won\'t be able to restore later.</string>
     <string name="RegistrationActivity_backup_size_s">Backup size: %s</string>
     <string name="RegistrationActivity_backup_timestamp_s">Backup timestamp: %s</string>
     <string name="BackupDialog_enable_local_backups">Enable local backups?</string>

--- a/res/xml/preferences_chats.xml
+++ b/res/xml/preferences_chats.xml
@@ -87,7 +87,7 @@
                 android:defaultValue="false"
                 android:key="pref_backup_enabled"
                 android:title="@string/preferences_chats__chat_backups"
-                android:summary="@string/preferences_chats__backup_chats_to_external_storage" />
+                android:summary="@string/preferences_chats__backup_chats_media_and_safety_numbers_to_external_storage" />
 
         <org.thoughtcrime.securesms.preferences.widgets.ProgressPreference
                 android:key="pref_backup_create"

--- a/src/org/thoughtcrime/securesms/RegistrationActivity.java
+++ b/src/org/thoughtcrime/securesms/RegistrationActivity.java
@@ -758,7 +758,7 @@ public class RegistrationActivity extends BaseActionBarActivity implements Verif
     subtitle.animate().translationX(subtitle.getWidth()).setDuration(SCENE_TRANSITION_DURATION).setListener(new AnimationCompleteListener() {
       @Override
       public void onAnimationEnd(Animator animation) {
-        subtitle.setText(R.string.RegistrationActivity_restore_your_messages_and_media_from_a_local_backup);
+        subtitle.setText(R.string.RegistrationActivity_restore_your_chats_media_and_safety_numbers_from_a_local_backup);
         subtitle.clearAnimation();
         subtitle.setTranslationX(-1 * subtitle.getWidth());
         subtitle.animate().translationX(0).setListener(null).setInterpolator(new OvershootInterpolator()).setDuration(SCENE_TRANSITION_DURATION).start();


### PR DESCRIPTION
#### Rationale 

Currently the encrypted backup-blobs contain 

1.  chat-history
1.  media
1.  safety-nums (and other cryptographic key-material) 

This means that when you restore a backup-blob with the 30-digit decrypt-passphrase, you get your signal-identity restored (*not* just your non-disappeared message-transcripts).  

#### Specific changes made 

Emphasize the fact that backup-blobs contain the crypto-keys, by saying "chats, media, and safety-numbers"  in the UI strings, rather than eliding mention of the lattermost.  

####  Release notes for test-pilots 

This is a simple change to user-visible strings (two of them) in the UI, and not complex enough to need a toggle-switch in the settings.  Test-pilots can perform A/B comparison by installing sigGesT x1 on the same handset as stock Signal-Android, and opening both apps simultaneously to the appropriate places in the UI.  Please verify that the wording is an improvement, and that there is no truncation or other ugly unintended side-effect.  

####  Known bugs

Only changes the top-level English-language strings.xml -- did NOT yet change all fifty-something OTHER strings.xml files for other languages.  <s>This might cause app-crash if the test-pilot's locale is not English?  </s> <ins>Per @valldrac , this will cause fallback-to-english-language-flavour for the 2 altered strings, so that's reasonable-ish.</ins> 

Did not attempt to translate from English into the other languages either (because such things are handled via transifex -- not via PRs to signalapp).  