### PR TITLE
Tiny screens: context menu width

### DIFF
--- a/res/menu/conversation_context.xml
+++ b/res/menu/conversation_context.xml
@@ -13,7 +13,7 @@
     <item android:title="@string/conversation_context__menu_copy_text"
           android:id="@+id/menu_context_copy"
           android:icon="?menu_copy_icon"
-          app:showAsAction="always" />
+          app:showAsAction="ifRoom" />
 
     <item android:title="@string/conversation_context__menu_forward_message"
           android:id="@+id/menu_context_forward"
@@ -29,7 +29,7 @@
           android:id="@+id/menu_context_save_attachment"
           android:visible="false"
           android:icon="?menu_save_icon"
-          app:showAsAction="always" />
+          app:showAsAction="ifRoom" />
 
     <item android:title="@string/conversation_context__menu_reply_to_message"
           android:id="@+id/menu_context_reply"

--- a/res/menu/conversation_context.xml
+++ b/res/menu/conversation_context.xml
@@ -3,12 +3,12 @@
     <item android:title="@string/conversation_context__menu_message_details"
           android:id="@+id/menu_context_details"
           android:icon="?menu_info_icon"
-          app:showAsAction="always" />
+          app:showAsAction="ifRoom" />
 
     <item android:title="@string/conversation_context__menu_delete_message"
         android:id="@+id/menu_context_delete_message"
         android:icon="?menu_trash_icon"
-        app:showAsAction="always" />
+        app:showAsAction="ifRoom" />
 
     <item android:title="@string/conversation_context__menu_copy_text"
           android:id="@+id/menu_context_copy"


### PR DESCRIPTION
In small screen devices the it's not possible to access some menu items
of the menu shown when selecting a message.

So, specify that some of the items could be moved into the context menu
when there isn't enough space for all of them.