### PR TITLE
i18n/backup time clarity

### DIFF
--- a/res/layout/backup_enable_dialog.xml
+++ b/res/layout/backup_enable_dialog.xml
@@ -11,7 +11,7 @@
     <TextView android:layout_width="match_parent"
               android:layout_height="wrap_content"
               android:textSize="12sp"
-              android:text="@string/backup_enable_dialog__backups_will_be_saved_to_external_storage_and_encrypted_with_the_passphrase_below_you_must_have_this_passphrase_in_order_to_restore_a_backup"/>
+              android:text="@string/backup_enable_dialog__backups_will_be_saved_to_external_storage_encrypted_with_the_passphrase_below"/>
 
     <TableLayout android:id="@+id/number_table"
                  android:layout_width="wrap_content"

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -1474,7 +1474,7 @@
     <string name="ExperienceUpgradeActivity_unlock_to_complete_update">Unlock to complete update</string>
     <string name="ExperienceUpgradeActivity_please_unlock_signal_to_complete_update">Please unlock Signal to complete update</string>
     <string name="enter_backup_passphrase_dialog__backup_passphrase">Backup passphrase</string>
-    <string name="backup_enable_dialog__backups_will_be_saved_to_external_storage_and_encrypted_with_the_passphrase_below_you_must_have_this_passphrase_in_order_to_restore_a_backup">Backups will be saved to external storage, encrypted with the passphrase below. You must have this 30-digit passphrase in order to restore a backup later on.</string>
+    <string name="backup_enable_dialog__backups_will_be_saved_to_external_storage_encrypted_with_the_passphrase_below">Backups will be saved to external storage, encrypted with the passphrase below. You must have this 30-digit passphrase in order to restore a backup later on.</string>
     <string name="backup_enable_dialog__i_have_written_down_this_passphrase">I have written down this passphrase. Without it, I will be unable to restore a backup later on.</string>
     <string name="registration_activity__restore_backup">Restore backup</string>
     <string name="registration_activity__skip">Skip</string>
@@ -1500,7 +1500,7 @@
     <string name="BackupDialog_delete_backups_statement">Delete backups</string>
     <string name="BackupDialog_copied_to_clipboard">Copied to clipboard</string>
     <string name="ChatsPreferenceFragment_signal_requires_external_storage_permission_in_order_to_create_backups">Signal requires external storage permission in order to create backups, but it has been permanently denied. Please continue to app settings, select \"Permissions\" and enable \"Storage\".</string>
-    <string name="ChatsPreferenceFragment_last_backup_s">Most recent backup: %s</string>
+    <string name="ChatsPreferenceFragment_most_recent_backup_s">Most recent backup: %s</string>
     <string name="ChatsPreferenceFragment_in_progress">In progress</string>
     <string name="LocalBackupJob_creating_backup">Creating backup...</string>
     <string name="ProgressPreference_d_messages_so_far">%d messages so far</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -1474,14 +1474,14 @@
     <string name="ExperienceUpgradeActivity_unlock_to_complete_update">Unlock to complete update</string>
     <string name="ExperienceUpgradeActivity_please_unlock_signal_to_complete_update">Please unlock Signal to complete update</string>
     <string name="enter_backup_passphrase_dialog__backup_passphrase">Backup passphrase</string>
-    <string name="backup_enable_dialog__backups_will_be_saved_to_external_storage_and_encrypted_with_the_passphrase_below_you_must_have_this_passphrase_in_order_to_restore_a_backup">Backups will be saved to external storage and encrypted with the passphrase below. You must have this passphrase in order to restore a backup.</string>
-    <string name="backup_enable_dialog__i_have_written_down_this_passphrase">I have written down this passphrase. Without it, I will be unable to restore a backup.</string>
+    <string name="backup_enable_dialog__backups_will_be_saved_to_external_storage_and_encrypted_with_the_passphrase_below_you_must_have_this_passphrase_in_order_to_restore_a_backup">Backups will be saved to external storage, encrypted with the passphrase below. You must have this 30-digit passphrase in order to restore a backup later on.</string>
+    <string name="backup_enable_dialog__i_have_written_down_this_passphrase">I have written down this passphrase. Without it, I will be unable to restore a backup later on.</string>
     <string name="registration_activity__restore_backup">Restore backup</string>
     <string name="registration_activity__skip">Skip</string>
     <string name="registration_activity__register">Register</string>
-    <string name="preferences_chats__chat_backups">Chat backups</string>
+    <string name="preferences_chats__chat_backups">Create backups</string>
     <string name="preferences_chats__backup_chats_to_external_storage">Backup chats to external storage</string>
-    <string name="preferences_chats__create_backup">Create backup</string>
+    <string name="preferences_chats__create_backup">Create backups (starting now)</string>
     <string name="RegistrationActivity_enter_backup_passphrase">Enter backup passphrase</string>
     <string name="RegistrationActivity_restore">Restore</string>
     <string name="RegistrationActivity_backup_failure_downgrade">Cannot import backups from newer versions of Signal</string>
@@ -1489,7 +1489,7 @@
     <string name="RegistrationActivity_checking">Checking...</string>
     <string name="RegistrationActivity_d_messages_so_far">%d messages so far...</string>
     <string name="RegistrationActivity_restore_from_backup">Restore from backup?</string>
-    <string name="RegistrationActivity_restore_your_messages_and_media_from_a_local_backup">Restore your messages and media from a local backup. If you don\'t restore now, you won\'t be able to restore later.</string>
+    <string name="RegistrationActivity_restore_your_messages_and_media_from_a_local_backup">Restore your messages and media from a local backup. Note: Restoring a backup can ONLY be done during the process of installing Signal. You cannot restore a backup once you’ve started using Signal without re-installing, so if you wish to restore a backup, please do so now.</string>
     <string name="RegistrationActivity_backup_size_s">Backup size: %s</string>
     <string name="RegistrationActivity_backup_timestamp_s">Backup timestamp: %s</string>
     <string name="BackupDialog_enable_local_backups">Enable local backups?</string>
@@ -1500,7 +1500,7 @@
     <string name="BackupDialog_delete_backups_statement">Delete backups</string>
     <string name="BackupDialog_copied_to_clipboard">Copied to clipboard</string>
     <string name="ChatsPreferenceFragment_signal_requires_external_storage_permission_in_order_to_create_backups">Signal requires external storage permission in order to create backups, but it has been permanently denied. Please continue to app settings, select \"Permissions\" and enable \"Storage\".</string>
-    <string name="ChatsPreferenceFragment_last_backup_s">Last backup: %s</string>
+    <string name="ChatsPreferenceFragment_last_backup_s">Most recent backup: %s</string>
     <string name="ChatsPreferenceFragment_in_progress">In progress</string>
     <string name="LocalBackupJob_creating_backup">Creating backup...</string>
     <string name="ProgressPreference_d_messages_so_far">%d messages so far</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -1479,9 +1479,9 @@
     <string name="registration_activity__restore_backup">Restore backup</string>
     <string name="registration_activity__skip">Skip</string>
     <string name="registration_activity__register">Register</string>
-    <string name="preferences_chats__chat_backups">Create backups</string>
+    <string name="preferences_chats__create_backups_every_24_hours">Create backups (every 24 hours)</string>
     <string name="preferences_chats__backup_chats_to_external_storage">Backup chats to external storage</string>
-    <string name="preferences_chats__create_backup">Create backups (starting now)</string>
+    <string name="preferences_chats__create_new_backup_now">Create new backup (now)</string>
     <string name="RegistrationActivity_enter_backup_passphrase">Enter backup passphrase</string>
     <string name="RegistrationActivity_restore">Restore</string>
     <string name="RegistrationActivity_backup_failure_downgrade">Cannot import backups from newer versions of Signal</string>

--- a/res/xml/preferences_chats.xml
+++ b/res/xml/preferences_chats.xml
@@ -91,7 +91,7 @@
 
         <org.thoughtcrime.securesms.preferences.widgets.ProgressPreference
                 android:key="pref_backup_create"
-                android:title="@string/preferences_chats__create_backups_starting_now"
+                android:title="@string/preferences_chats__create_new_backup_now"
                 android:persistent="false"
                 android:dependency="pref_backup_enabled"
                 tools:summary="Last backup: 3 days ago"/>

--- a/res/xml/preferences_chats.xml
+++ b/res/xml/preferences_chats.xml
@@ -86,7 +86,7 @@
         <org.thoughtcrime.securesms.components.SwitchPreferenceCompat
                 android:defaultValue="false"
                 android:key="pref_backup_enabled"
-                android:title="@string/preferences_chats__create_backups"
+                android:title="@string/preferences_chats__create_backups_every_24_hours"
                 android:summary="@string/preferences_chats__backup_chats_to_external_storage" />
 
         <org.thoughtcrime.securesms.preferences.widgets.ProgressPreference

--- a/res/xml/preferences_chats.xml
+++ b/res/xml/preferences_chats.xml
@@ -86,12 +86,12 @@
         <org.thoughtcrime.securesms.components.SwitchPreferenceCompat
                 android:defaultValue="false"
                 android:key="pref_backup_enabled"
-                android:title="@string/preferences_chats__chat_backups"
+                android:title="@string/preferences_chats__create_backups"
                 android:summary="@string/preferences_chats__backup_chats_to_external_storage" />
 
         <org.thoughtcrime.securesms.preferences.widgets.ProgressPreference
                 android:key="pref_backup_create"
-                android:title="@string/preferences_chats__create_backup"
+                android:title="@string/preferences_chats__create_backups_starting_now"
                 android:persistent="false"
                 android:dependency="pref_backup_enabled"
                 tools:summary="Last backup: 3 days ago"/>

--- a/src/org/thoughtcrime/securesms/preferences/ChatsPreferenceFragment.java
+++ b/src/org/thoughtcrime/securesms/preferences/ChatsPreferenceFragment.java
@@ -107,7 +107,7 @@ public class ChatsPreferenceFragment extends ListSummaryPreferenceFragment {
 
   private void setBackupSummary() {
     findPreference(TextSecurePreferences.BACKUP_NOW)
-        .setSummary(String.format(getString(R.string.ChatsPreferenceFragment_last_backup_s), BackupUtil.getLastBackupTime(getContext(), Locale.US)));
+        .setSummary(String.format(getString(R.string.ChatsPreferenceFragment_most_recent_backup_s), BackupUtil.getLastBackupTime(getContext(), Locale.US)));
   }
 
   private void setMediaDownloadSummaries() {


### PR DESCRIPTION
Changes six user-visible strings, to clarify when events happen during backups, i.e. timing-related phrases.  Also, altered one varname to be first-sentence-only (vs 162 bytes long) 

* Rationale:  TBD, will edit in release-notes later.  

*  Rough draft [prettydiffs](https://community.signalusers.org/t/ui-clarification-aka-mirving-then-upmerging-pr-8715/8226/2) (with some bugs though!) and 
* [discussion](https://community.signalusers.org/t/ui-clarification-aka-mirving-then-upmerging-pr-8715/8226/13), especially versus @Meteor0id 's 
* [PR#8715](https://github.com/signalapp/Signal-Android/pull/8715/files#diff-4691bafd7791e471b30c492e6f43d65bL1474), on (a subset of) which these alterations build. 

Please upload [your sigGesT debuglogs](https://github.com/sigx/sig4a/wiki/Quickstart) and screenshots and critiques [here... link TBD, will edit in later!] in a new comment, [after x1 is out](https://sigX.github.io). 